### PR TITLE
[cruise-control] new release: jdk17-cc2.5.140-iam2.2.0

### DIFF
--- a/charts/cruise-control/Chart.yaml
+++ b/charts/cruise-control/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 sources:
   - https://github.com/linkedin/cruise-control
 version: 1.0.0
-appVersion: jdk17-cc2.5.139-iam2.2.0
+appVersion: jdk17-cc2.5.140-iam2.2.0
 home: https://github.com/devops-ia/helm-cruise-control
 keywords:
   - cruise-control


### PR DESCRIPTION
Cruise Control version:
- :information_source: Current: `jdk17-cc2.5.139-iam2.2.0`
- :up: Upgrade: `jdk17-cc2.5.140-iam2.2.0`

Changelog: https://github.com/linkedin/cruise-control/releases/tag/2.5.140