### PR TITLE
[cruise-control] new release: jdk17-cc2.5.141-iam2.3.1

### DIFF
--- a/charts/cruise-control/Chart.yaml
+++ b/charts/cruise-control/Chart.yaml
@@ -8,8 +8,8 @@ maintainers:
     url: https://ialejandro.rocks
 sources:
   - https://github.com/linkedin/cruise-control
-version: 1.1.7
-appVersion: jdk17-cc2.5.141-iam2.3.0
+version: 1.1.8
+appVersion: jdk17-cc2.5.141-iam2.3.1
 home: https://github.com/devops-ia/helm-cruise-control
 keywords:
   - cruise-control


### PR DESCRIPTION
Cruise Control version:
- :information_source: Current: `jdk17-cc2.5.141-iam2.3.0`
- :up: Upgrade: `jdk17-cc2.5.141-iam2.3.1`

Changelog: https://github.com/linkedin/cruise-control/releases/tag/2.5.141