### PR TITLE
[cruise-control] new release: jdk17-cc3.0.2-iam2.3.1

### DIFF
--- a/charts/cruise-control/Chart.yaml
+++ b/charts/cruise-control/Chart.yaml
@@ -8,8 +8,8 @@ maintainers:
     url: https://ialejandro.rocks
 sources:
   - https://github.com/linkedin/cruise-control
-version: 1.0.3
-appVersion: jdk17-cc3.0.1-iam2.3.1
+version: 1.0.4
+appVersion: jdk17-cc3.0.2-iam2.3.1
 home: https://github.com/devops-ia/helm-cruise-control
 keywords:
   - cruise-control


### PR DESCRIPTION
Cruise Control version:
- :information_source: Current: `jdk17-cc3.0.1-iam2.3.1`
- :up: Upgrade: `jdk17-cc3.0.2-iam2.3.1`

Changelog: https://github.com/linkedin/cruise-control/releases/tag/3.0.2