### PR TITLE
[cruise-control] new release: jdk17-cc3.0.3-iam2.3.4

### DIFF
--- a/charts/cruise-control/Chart.yaml
+++ b/charts/cruise-control/Chart.yaml
@@ -8,8 +8,8 @@ maintainers:
     url: https://ialejandro.rocks
 sources:
   - https://github.com/linkedin/cruise-control
-version: 1.0.7
-appVersion: jdk17-cc3.0.3-iam2.3.3
+version: 1.0.8
+appVersion: jdk17-cc3.0.3-iam2.3.4
 home: https://github.com/devops-ia/helm-cruise-control
 keywords:
   - cruise-control


### PR DESCRIPTION
Cruise Control version:
- :information_source: Current: `jdk17-cc3.0.3-iam2.3.3`
- :up: Upgrade: `jdk17-cc3.0.3-iam2.3.4`

Changelog: https://github.com/linkedin/cruise-control/releases/tag/3.0.3