### PR TITLE
[cruise-control] new release: jdk17-cc2.5.146-iam2.3.6

### DIFF
--- a/charts/cruise-control/Chart.yaml
+++ b/charts/cruise-control/Chart.yaml
@@ -9,8 +9,8 @@ maintainers:
     url: https://ialejandro.rocks
 sources:
   - https://github.com/linkedin/cruise-control
-version: 2.0.1
-appVersion: jdk17-cc2.5.146-iam2.3.5
+version: 2.0.2
+appVersion: jdk17-cc2.5.146-iam2.3.6
 home: https://github.com/devops-ia/helm-cruise-control
 keywords:
   - cruise-control


### PR DESCRIPTION
Cruise Control version:
- :information_source: Current: `jdk17-cc2.5.146-iam2.3.5`
- :up: Upgrade: `jdk17-cc2.5.146-iam2.3.6`

Changelog: https://github.com/linkedin/cruise-control/releases/tag/2.5.146